### PR TITLE
Apply shellcheck linting suggestions

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ Please confirm you have requirements listed below:
 2- LND Lightning Node 
 3- Always available server/VM/self-hosted node"
 DEFAULT_REQUIREMENTS="n"
-read -e -p "y/n: " requirements
+read -erp "y/n: " requirements
 requirements="${requirements:-${DEFAULT_REQUIREMENTS}}"
 if [ "$requirements" != "y" ] ; then
     echo "Not ready yet, quitting."
@@ -27,7 +27,7 @@ if [ "$requirements" != "y" ] ; then
 fi
 
 echo -e "\nI understand that this is experimental software that may cause loss of funds."
-read -e -p "y/n: " reckless
+read -erp "y/n: " reckless
 reckless="${reckless:-${DEFAULT_REQUIREMENTS}}"
 if [ "${reckless}" != "y" ] ; then
   echo "Not #reckless yet, quitting."
@@ -36,60 +36,62 @@ fi
 
 echo ""
 DEFAULT_APP_DATA_DIR="$HOME/.lnstx-client"
-read -e -p "Folder where lnstxbridge client will keep its data [$DEFAULT_APP_DATA_DIR]: " APP_DATA_DIR
+read -erp "Folder where lnstxbridge client will keep its data [$DEFAULT_APP_DATA_DIR]: " APP_DATA_DIR
 APP_DATA_DIR="${APP_DATA_DIR:-${DEFAULT_APP_DATA_DIR}}"
 
 DEFAULT_LND_DATA_DIR="$HOME/.lnd"
-read -e -p "Folder where lnd is installed [$DEFAULT_LND_DATA_DIR]: " LND_DATA_DIR
+read -erp "Folder where lnd is installed [$DEFAULT_LND_DATA_DIR]: " LND_DATA_DIR
 LND_DATA_DIR="${LND_DATA_DIR:-${DEFAULT_LND_DATA_DIR}}"
 
 DEFAULT_BITCOIN_IP="127.0.0.1"
-read -e -p "Bitcoin Node IP [$DEFAULT_BITCOIN_IP]: " BITCOIN_IP
+read -erp "Bitcoin Node IP [$DEFAULT_BITCOIN_IP]: " BITCOIN_IP
 BITCOIN_IP="${BITCOIN_IP:-${DEFAULT_BITCOIN_IP}}"
 
 DEFAULT_BITCOIN_RPC_PORT="8332"
-read -e -p "Bitcoin Node RPC Port [$DEFAULT_BITCOIN_RPC_PORT]: " BITCOIN_RPC_PORT
+read -erp "Bitcoin Node RPC Port [$DEFAULT_BITCOIN_RPC_PORT]: " BITCOIN_RPC_PORT
 BITCOIN_RPC_PORT="${BITCOIN_RPC_PORT:-${DEFAULT_BITCOIN_RPC_PORT}}"
 
 DEFAULT_BITCOIN_RPC_USER="rpcuser"
-read -e -p "Bitcoin Node RPC User [$DEFAULT_BITCOIN_RPC_USER]: " BITCOIN_RPC_USER
+read -erp "Bitcoin Node RPC User [$DEFAULT_BITCOIN_RPC_USER]: " BITCOIN_RPC_USER
 BITCOIN_RPC_USER="${BITCOIN_RPC_USER:-${DEFAULT_BITCOIN_RPC_USER}}"
 
 DEFAULT_BITCOIN_RPC_PASS="rpcpass"
-read -e -p "Bitcoin Node RPC Password [$DEFAULT_BITCOIN_RPC_PASS]: " BITCOIN_RPC_PASS
+read -erp "Bitcoin Node RPC Password [$DEFAULT_BITCOIN_RPC_PASS]: " BITCOIN_RPC_PASS
 BITCOIN_RPC_PASS="${BITCOIN_RPC_PASS:-${DEFAULT_BITCOIN_RPC_PASS}}"
 
 DEFAULT_BITCOIN_NETWORK="mainnet"
-read -e -p "Bitcoin Node Network [$DEFAULT_BITCOIN_NETWORK]: " BITCOIN_NETWORK
+read -erp "Bitcoin Node Network [$DEFAULT_BITCOIN_NETWORK]: " BITCOIN_NETWORK
 BITCOIN_NETWORK="${BITCOIN_NETWORK:-${DEFAULT_BITCOIN_NETWORK}}"
 
 DEFAULT_LND_IP="127.0.0.1"
-read -e -p "LND Node IP [$DEFAULT_LND_IP]: " LND_IP
+read -erp "LND Node IP [$DEFAULT_LND_IP]: " LND_IP
 LND_IP="${LND_IP:-${DEFAULT_LND_IP}}"
 
 DEFAULT_LND_GRPC_PORT="10009"
-read -e -p "LND Node GRPC Port [$DEFAULT_LND_GRPC_PORT]: " LND_GRPC_PORT
+read -erp "LND Node GRPC Port [$DEFAULT_LND_GRPC_PORT]: " LND_GRPC_PORT
 LND_GRPC_PORT="${LND_GRPC_PORT:-${DEFAULT_LND_GRPC_PORT}}"
 
 DEFAULT_APP_PASSWORD="changeme!!!"
-read -e -p "LN-STX Client Admin Dashboard Password [$DEFAULT_APP_PASSWORD]: " APP_PASSWORD
+read -erp "LN-STX Client Admin Dashboard Password [$DEFAULT_APP_PASSWORD]: " APP_PASSWORD
 APP_PASSWORD="${APP_PASSWORD:-${DEFAULT_APP_PASSWORD}}"
 
 # use public ipv4 or create hidden service
 echo -e "\nDo you have an IPv4 address that this server is reachable from or is this a self-hosted node that we need to create a tor hidden service?"
 DEFAULT_ACCESS="tor"
-read -e -p "ip/tor: " access
+read -erp "ip/tor: " access
 access="${access:-${DEFAULT_ACCESS}}"
 if [ "${access}" == "tor" ] ; then
   echo "Creating tor hidden service..."
-  echo "HiddenServiceDir /var/lib/tor/lnswap/" >> /etc/tor/torrc
-  echo "HiddenServicePort 9008 127.0.0.1:9008" >> /etc/tor/torrc
-  echo "HiddenServicePort 80 127.0.0.1:9009" >> /etc/tor/torrc
-  `systemctl restart tor`
+  {
+    echo "HiddenServiceDir /var/lib/tor/lnswap/"
+    echo "HiddenServicePort 9008 127.0.0.1:9008"
+    echo "HiddenServicePort 80 127.0.0.1:9009"
+  } >> /etc/tor/torrc
+  eval "systemctl restart tor"
   sleep 5
-  APP_LNSWAP_API_IP=`cat /var/lib/tor/lnswap/hostname`
+  APP_LNSWAP_API_IP=$(cat /var/lib/tor/lnswap/hostname)
 else
-    read -e -p "Enter your server IP: " APP_LNSWAP_API_IP
+    read -erp "Enter your server IP: " APP_LNSWAP_API_IP
 fi
 
 echo -e "\nInstalling lnstxbridge-client with following environment variables: "
@@ -109,46 +111,46 @@ if ! [ -x "$(command -v docker-compose)" ]; then
     echo "trying to install docker-compose..."
     VERSION=$(curl --silent https://api.github.com/repos/docker/compose/releases/latest | jq .name -r)
     DESTINATION=/usr/local/bin/docker-compose
-    sudo curl -L https://github.com/docker/compose/releases/download/${VERSION}/docker-compose-$(uname -s)-$(uname -m) -o $DESTINATION
+    sudo curl -L https://github.com/docker/compose/releases/download/"${VERSION}"/docker-compose-"$(uname -s)"-"$(uname -m)" -o $DESTINATION
     sudo chmod 755 $DESTINATION
 fi
 
 # create lnstxbridge-client data folder
-mkdir -p $APP_DATA_DIR/data
+mkdir -p "$APP_DATA_DIR/data"
 
 # download docker-compose.yml
-cd $APP_DATA_DIR
+cd "$APP_DATA_DIR" || exit
 curl -O "https://cdn.jsdelivr.net/gh/pseudozach/lnstxbridge-client@main/docker-compose/docker-compose.yml"
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
     # macos sed is different
-    sed -i '' 's#$APP_DATA_DIR#'$APP_DATA_DIR'#g' docker-compose.yml
-    sed -i '' 's#$LND_DATA_DIR#'$LND_DATA_DIR'#g' docker-compose.yml
-    sed -i '' 's#$BITCOIN_IP#'$BITCOIN_IP'#g' docker-compose.yml
-    sed -i '' 's#$BITCOIN_RPC_PORT#'$BITCOIN_RPC_PORT'#g' docker-compose.yml
-    sed -i '' 's#$BITCOIN_RPC_USER#'$BITCOIN_RPC_USER'#g' docker-compose.yml
-    sed -i '' 's#$BITCOIN_RPC_PASS#'$BITCOIN_RPC_PASS'#g' docker-compose.yml
-    sed -i '' 's#$BITCOIN_NETWORK#'$BITCOIN_NETWORK'#g' docker-compose.yml
-    sed -i '' 's#$LND_IP#'$LND_IP'#g' docker-compose.yml
-    sed -i '' 's#$LND_GRPC_PORT#'$LND_GRPC_PORT'#g' docker-compose.yml
-    sed -i '' 's#$APP_PASSWORD#'$APP_PASSWORD'#g' docker-compose.yml
-    sed -i '' 's#$APP_LNSWAP_API_IP#'$APP_LNSWAP_API_IP'#g' docker-compose.yml
+    eval sed -i '' 's#$APP_DATA_DIR#'"$APP_DATA_DIR"'#g' docker-compose.yml
+    eval sed -i '' 's#$LND_DATA_DIR#'"$LND_DATA_DIR"'#g' docker-compose.yml
+    eval sed -i '' 's#$BITCOIN_IP#'"$BITCOIN_IP"'#g' docker-compose.yml
+    eval sed -i '' 's#$BITCOIN_RPC_PORT#'"$BITCOIN_RPC_PORT"'#g' docker-compose.yml
+    eval sed -i '' 's#$BITCOIN_RPC_USER#'"$BITCOIN_RPC_USER"'#g' docker-compose.yml
+    eval sed -i '' 's#$BITCOIN_RPC_PASS#'"$BITCOIN_RPC_PASS"'#g' docker-compose.yml
+    eval sed -i '' 's#$BITCOIN_NETWORK#'"$BITCOIN_NETWORK"'#g' docker-compose.yml
+    eval sed -i '' 's#$LND_IP#'"$LND_IP"'#g' docker-compose.yml
+    eval sed -i '' 's#$LND_GRPC_PORT#'"$LND_GRPC_PORT"'#g' docker-compose.yml
+    eval sed -i '' 's#$APP_PASSWORD#'"$APP_PASSWORD"'#g' docker-compose.yml
+    eval sed -i '' 's#$APP_LNSWAP_API_IP#'"$APP_LNSWAP_API_IP"'#g' docker-compose.yml
 else
-    sed -i 's#$APP_DATA_DIR#'$APP_DATA_DIR'#g' docker-compose.yml
-    sed -i 's#$LND_DATA_DIR#'$LND_DATA_DIR'#g' docker-compose.yml
-    sed -i 's#$BITCOIN_IP#'$BITCOIN_IP'#g' docker-compose.yml
-    sed -i 's#$BITCOIN_RPC_PORT#'$BITCOIN_RPC_PORT'#g' docker-compose.yml
-    sed -i 's#$BITCOIN_RPC_USER#'$BITCOIN_RPC_USER'#g' docker-compose.yml
-    sed -i 's#$BITCOIN_RPC_PASS#'$BITCOIN_RPC_PASS'#g' docker-compose.yml
-    sed -i 's#$BITCOIN_NETWORK#'$BITCOIN_NETWORK'#g' docker-compose.yml
-    sed -i 's#$LND_IP#'$LND_IP'#g' docker-compose.yml
-    sed -i 's#$LND_GRPC_PORT#'$LND_GRPC_PORT'#g' docker-compose.yml
-    sed -i 's#$APP_PASSWORD#'$APP_PASSWORD'#g' docker-compose.yml
-    sed -i 's#$APP_LNSWAP_API_IP#'$APP_LNSWAP_API_IP'#g' docker-compose.yml
+    eval sed -i 's#$APP_DATA_DIR#'"$APP_DATA_DIR"'#g' docker-compose.yml
+    eval sed -i 's#$LND_DATA_DIR#'"$LND_DATA_DIR"'#g' docker-compose.yml
+    eval sed -i 's#$BITCOIN_IP#'"$BITCOIN_IP"'#g' docker-compose.yml
+    eval sed -i 's#$BITCOIN_RPC_PORT#'"$BITCOIN_RPC_PORT"'#g' docker-compose.yml
+    eval sed -i 's#$BITCOIN_RPC_USER#'"$BITCOIN_RPC_USER"'#g' docker-compose.yml
+    eval sed -i 's#$BITCOIN_RPC_PASS#'"$BITCOIN_RPC_PASS"'#g' docker-compose.yml
+    eval sed -i 's#$BITCOIN_NETWORK#'"$BITCOIN_NETWORK"'#g' docker-compose.yml
+    eval sed -i 's#$LND_IP#'"$LND_IP"'#g' docker-compose.yml
+    eval sed -i 's#$LND_GRPC_PORT#'"$LND_GRPC_PORT"'#g' docker-compose.yml
+    eval sed -i 's#$APP_PASSWORD#'"$APP_PASSWORD"'#g' docker-compose.yml
+    eval sed -i 's#$APP_LNSWAP_API_IP#'"$APP_LNSWAP_API_IP"'#g' docker-compose.yml
 fi
 
 # copy boltz.conf template to APP_DATA_DIR/data = /root/.lnstx-client inside container
-cd $APP_DATA_DIR/data
+cd "$APP_DATA_DIR/data" || exit
 curl -O "https://cdn.jsdelivr.net/gh/pseudozach/lnstxbridge-client@main/docker-compose/lnstx-client/boltz.conf"
 
 # start containers


### PR DESCRIPTION
This PR lints the file and applies all suggestions based on [shellcheck](https://github.com/koalaman/shellcheck).

The main changes were:

- adding `-r` to the `read` commands (and simplifying layout)
- quoting variables to prevent word splitting
- add exits when switching to directories (if they don't exist)
- use `eval` and `$()` formatting for commands instead of backticks

I have some additional ideas on formatting and control flow, but will set those up in a separate PR so we can discuss it in more detail.