### PR TITLE
Update control flow

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ Please confirm you have requirements listed below:
 2- LND Lightning Node 
 3- Always available server/VM/self-hosted node"
 DEFAULT_REQUIREMENTS="n"
-read -e -p "y/n: " requirements
+read -erp "y/n: " requirements
 requirements="${requirements:-${DEFAULT_REQUIREMENTS}}"
 if [ "$requirements" != "y" ] ; then
     echo "Not ready yet, quitting."
@@ -27,7 +27,7 @@ if [ "$requirements" != "y" ] ; then
 fi
 
 echo -e "\nI understand that this is experimental software that may cause loss of funds."
-read -e -p "y/n: " reckless
+read -erp "y/n: " reckless
 reckless="${reckless:-${DEFAULT_REQUIREMENTS}}"
 if [ "${reckless}" != "y" ] ; then
   echo "Not #reckless yet, quitting."
@@ -36,60 +36,62 @@ fi
 
 echo ""
 DEFAULT_APP_DATA_DIR="$HOME/.lnstx-client"
-read -e -p "Folder where lnstxbridge client will keep its data [$DEFAULT_APP_DATA_DIR]: " APP_DATA_DIR
+read -erp "Folder where lnstxbridge client will keep its data [$DEFAULT_APP_DATA_DIR]: " APP_DATA_DIR
 APP_DATA_DIR="${APP_DATA_DIR:-${DEFAULT_APP_DATA_DIR}}"
 
 DEFAULT_LND_DATA_DIR="$HOME/.lnd"
-read -e -p "Folder where lnd is installed [$DEFAULT_LND_DATA_DIR]: " LND_DATA_DIR
+read -erp "Folder where lnd is installed [$DEFAULT_LND_DATA_DIR]: " LND_DATA_DIR
 LND_DATA_DIR="${LND_DATA_DIR:-${DEFAULT_LND_DATA_DIR}}"
 
 DEFAULT_BITCOIN_IP="127.0.0.1"
-read -e -p "Bitcoin Node IP [$DEFAULT_BITCOIN_IP]: " BITCOIN_IP
+read -erp "Bitcoin Node IP [$DEFAULT_BITCOIN_IP]: " BITCOIN_IP
 BITCOIN_IP="${BITCOIN_IP:-${DEFAULT_BITCOIN_IP}}"
 
 DEFAULT_BITCOIN_RPC_PORT="8332"
-read -e -p "Bitcoin Node RPC Port [$DEFAULT_BITCOIN_RPC_PORT]: " BITCOIN_RPC_PORT
+read -erp "Bitcoin Node RPC Port [$DEFAULT_BITCOIN_RPC_PORT]: " BITCOIN_RPC_PORT
 BITCOIN_RPC_PORT="${BITCOIN_RPC_PORT:-${DEFAULT_BITCOIN_RPC_PORT}}"
 
 DEFAULT_BITCOIN_RPC_USER="rpcuser"
-read -e -p "Bitcoin Node RPC User [$DEFAULT_BITCOIN_RPC_USER]: " BITCOIN_RPC_USER
+read -erp "Bitcoin Node RPC User [$DEFAULT_BITCOIN_RPC_USER]: " BITCOIN_RPC_USER
 BITCOIN_RPC_USER="${BITCOIN_RPC_USER:-${DEFAULT_BITCOIN_RPC_USER}}"
 
 DEFAULT_BITCOIN_RPC_PASS="rpcpass"
-read -e -p "Bitcoin Node RPC Password [$DEFAULT_BITCOIN_RPC_PASS]: " BITCOIN_RPC_PASS
+read -erp "Bitcoin Node RPC Password [$DEFAULT_BITCOIN_RPC_PASS]: " BITCOIN_RPC_PASS
 BITCOIN_RPC_PASS="${BITCOIN_RPC_PASS:-${DEFAULT_BITCOIN_RPC_PASS}}"
 
 DEFAULT_BITCOIN_NETWORK="mainnet"
-read -e -p "Bitcoin Node Network [$DEFAULT_BITCOIN_NETWORK]: " BITCOIN_NETWORK
+read -erp "Bitcoin Node Network [$DEFAULT_BITCOIN_NETWORK]: " BITCOIN_NETWORK
 BITCOIN_NETWORK="${BITCOIN_NETWORK:-${DEFAULT_BITCOIN_NETWORK}}"
 
 DEFAULT_LND_IP="127.0.0.1"
-read -e -p "LND Node IP [$DEFAULT_LND_IP]: " LND_IP
+read -erp "LND Node IP [$DEFAULT_LND_IP]: " LND_IP
 LND_IP="${LND_IP:-${DEFAULT_LND_IP}}"
 
 DEFAULT_LND_GRPC_PORT="10009"
-read -e -p "LND Node GRPC Port [$DEFAULT_LND_GRPC_PORT]: " LND_GRPC_PORT
+read -erp "LND Node GRPC Port [$DEFAULT_LND_GRPC_PORT]: " LND_GRPC_PORT
 LND_GRPC_PORT="${LND_GRPC_PORT:-${DEFAULT_LND_GRPC_PORT}}"
 
 DEFAULT_APP_PASSWORD="changeme!!!"
-read -e -p "LN-STX Client Admin Dashboard Password [$DEFAULT_APP_PASSWORD]: " APP_PASSWORD
+read -erp "LN-STX Client Admin Dashboard Password [$DEFAULT_APP_PASSWORD]: " APP_PASSWORD
 APP_PASSWORD="${APP_PASSWORD:-${DEFAULT_APP_PASSWORD}}"
 
 # use public ipv4 or create hidden service
 echo -e "\nDo you have an IPv4 address that this server is reachable from or is this a self-hosted node that we need to create a tor hidden service?"
 DEFAULT_ACCESS="tor"
-read -e -p "ip/tor: " access
+read -erp "ip/tor: " access
 access="${access:-${DEFAULT_ACCESS}}"
 if [ "${access}" == "tor" ] ; then
   echo "Creating tor hidden service..."
-  echo "HiddenServiceDir /var/lib/tor/lnswap/" >> /etc/tor/torrc
-  echo "HiddenServicePort 9008 127.0.0.1:9008" >> /etc/tor/torrc
-  echo "HiddenServicePort 80 127.0.0.1:9009" >> /etc/tor/torrc
-  `systemctl restart tor`
+  {
+    echo "HiddenServiceDir /var/lib/tor/lnswap/"
+    echo "HiddenServicePort 9008 127.0.0.1:9008"
+    echo "HiddenServicePort 80 127.0.0.1:9009"
+  } >> /etc/tor/torrc
+  eval "systemctl restart tor"
   sleep 5
-  APP_LNSWAP_API_IP=`cat /var/lib/tor/lnswap/hostname`
+  APP_LNSWAP_API_IP=$(cat /var/lib/tor/lnswap/hostname)
 else
-    read -e -p "Enter your server IP: " APP_LNSWAP_API_IP
+    read -erp "Enter your server IP: " APP_LNSWAP_API_IP
 fi
 
 echo -e "\nInstalling lnstxbridge-client with following environment variables: "
@@ -109,46 +111,46 @@ if ! [ -x "$(command -v docker-compose)" ]; then
     echo "trying to install docker-compose..."
     VERSION=$(curl --silent https://api.github.com/repos/docker/compose/releases/latest | jq .name -r)
     DESTINATION=/usr/local/bin/docker-compose
-    sudo curl -L https://github.com/docker/compose/releases/download/${VERSION}/docker-compose-$(uname -s)-$(uname -m) -o $DESTINATION
+    sudo curl -L https://github.com/docker/compose/releases/download/"${VERSION}"/docker-compose-"$(uname -s)"-"$(uname -m)" -o $DESTINATION
     sudo chmod 755 $DESTINATION
 fi
 
 # create lnstxbridge-client data folder
-mkdir -p $APP_DATA_DIR/data
+mkdir -p "$APP_DATA_DIR/data"
 
 # download docker-compose.yml
-cd $APP_DATA_DIR
+cd "$APP_DATA_DIR" || exit
 curl -O "https://cdn.jsdelivr.net/gh/pseudozach/lnstxbridge-client@main/docker-compose/docker-compose.yml"
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
     # macos sed is different
-    sed -i '' 's#$APP_DATA_DIR#'$APP_DATA_DIR'#g' docker-compose.yml
-    sed -i '' 's#$LND_DATA_DIR#'$LND_DATA_DIR'#g' docker-compose.yml
-    sed -i '' 's#$BITCOIN_IP#'$BITCOIN_IP'#g' docker-compose.yml
-    sed -i '' 's#$BITCOIN_RPC_PORT#'$BITCOIN_RPC_PORT'#g' docker-compose.yml
-    sed -i '' 's#$BITCOIN_RPC_USER#'$BITCOIN_RPC_USER'#g' docker-compose.yml
-    sed -i '' 's#$BITCOIN_RPC_PASS#'$BITCOIN_RPC_PASS'#g' docker-compose.yml
-    sed -i '' 's#$BITCOIN_NETWORK#'$BITCOIN_NETWORK'#g' docker-compose.yml
-    sed -i '' 's#$LND_IP#'$LND_IP'#g' docker-compose.yml
-    sed -i '' 's#$LND_GRPC_PORT#'$LND_GRPC_PORT'#g' docker-compose.yml
-    sed -i '' 's#$APP_PASSWORD#'$APP_PASSWORD'#g' docker-compose.yml
-    sed -i '' 's#$APP_LNSWAP_API_IP#'$APP_LNSWAP_API_IP'#g' docker-compose.yml
+    eval sed -i '' 's#$APP_DATA_DIR#'"$APP_DATA_DIR"'#g' docker-compose.yml
+    eval sed -i '' 's#$LND_DATA_DIR#'"$LND_DATA_DIR"'#g' docker-compose.yml
+    eval sed -i '' 's#$BITCOIN_IP#'"$BITCOIN_IP"'#g' docker-compose.yml
+    eval sed -i '' 's#$BITCOIN_RPC_PORT#'"$BITCOIN_RPC_PORT"'#g' docker-compose.yml
+    eval sed -i '' 's#$BITCOIN_RPC_USER#'"$BITCOIN_RPC_USER"'#g' docker-compose.yml
+    eval sed -i '' 's#$BITCOIN_RPC_PASS#'"$BITCOIN_RPC_PASS"'#g' docker-compose.yml
+    eval sed -i '' 's#$BITCOIN_NETWORK#'"$BITCOIN_NETWORK"'#g' docker-compose.yml
+    eval sed -i '' 's#$LND_IP#'"$LND_IP"'#g' docker-compose.yml
+    eval sed -i '' 's#$LND_GRPC_PORT#'"$LND_GRPC_PORT"'#g' docker-compose.yml
+    eval sed -i '' 's#$APP_PASSWORD#'"$APP_PASSWORD"'#g' docker-compose.yml
+    eval sed -i '' 's#$APP_LNSWAP_API_IP#'"$APP_LNSWAP_API_IP"'#g' docker-compose.yml
 else
-    sed -i 's#$APP_DATA_DIR#'$APP_DATA_DIR'#g' docker-compose.yml
-    sed -i 's#$LND_DATA_DIR#'$LND_DATA_DIR'#g' docker-compose.yml
-    sed -i 's#$BITCOIN_IP#'$BITCOIN_IP'#g' docker-compose.yml
-    sed -i 's#$BITCOIN_RPC_PORT#'$BITCOIN_RPC_PORT'#g' docker-compose.yml
-    sed -i 's#$BITCOIN_RPC_USER#'$BITCOIN_RPC_USER'#g' docker-compose.yml
-    sed -i 's#$BITCOIN_RPC_PASS#'$BITCOIN_RPC_PASS'#g' docker-compose.yml
-    sed -i 's#$BITCOIN_NETWORK#'$BITCOIN_NETWORK'#g' docker-compose.yml
-    sed -i 's#$LND_IP#'$LND_IP'#g' docker-compose.yml
-    sed -i 's#$LND_GRPC_PORT#'$LND_GRPC_PORT'#g' docker-compose.yml
-    sed -i 's#$APP_PASSWORD#'$APP_PASSWORD'#g' docker-compose.yml
-    sed -i 's#$APP_LNSWAP_API_IP#'$APP_LNSWAP_API_IP'#g' docker-compose.yml
+    eval sed -i 's#$APP_DATA_DIR#'"$APP_DATA_DIR"'#g' docker-compose.yml
+    eval sed -i 's#$LND_DATA_DIR#'"$LND_DATA_DIR"'#g' docker-compose.yml
+    eval sed -i 's#$BITCOIN_IP#'"$BITCOIN_IP"'#g' docker-compose.yml
+    eval sed -i 's#$BITCOIN_RPC_PORT#'"$BITCOIN_RPC_PORT"'#g' docker-compose.yml
+    eval sed -i 's#$BITCOIN_RPC_USER#'"$BITCOIN_RPC_USER"'#g' docker-compose.yml
+    eval sed -i 's#$BITCOIN_RPC_PASS#'"$BITCOIN_RPC_PASS"'#g' docker-compose.yml
+    eval sed -i 's#$BITCOIN_NETWORK#'"$BITCOIN_NETWORK"'#g' docker-compose.yml
+    eval sed -i 's#$LND_IP#'"$LND_IP"'#g' docker-compose.yml
+    eval sed -i 's#$LND_GRPC_PORT#'"$LND_GRPC_PORT"'#g' docker-compose.yml
+    eval sed -i 's#$APP_PASSWORD#'"$APP_PASSWORD"'#g' docker-compose.yml
+    eval sed -i 's#$APP_LNSWAP_API_IP#'"$APP_LNSWAP_API_IP"'#g' docker-compose.yml
 fi
 
 # copy boltz.conf template to APP_DATA_DIR/data = /root/.lnstx-client inside container
-cd $APP_DATA_DIR/data
+cd "$APP_DATA_DIR/data" || exit
 curl -O "https://cdn.jsdelivr.net/gh/pseudozach/lnstxbridge-client@main/docker-compose/lnstx-client/boltz.conf"
 
 # start containers

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
-echo "
+set -euo pipefail
+shopt -s expand_aliases
+
+LOGO="
 ₿₿\      ₿₿\   ₿₿\  ₿₿₿₿₿₿\  ₿₿\      ₿₿\  ₿₿₿₿₿₿\  ₿₿₿₿₿₿₿\  
 ₿₿ |     ₿₿₿\  ₿₿ |₿₿  __₿₿\ ₿₿ | ₿\  ₿₿ |₿₿  __₿₿\ ₿₿  __₿₿\ 
 ₿₿ |     ₿₿₿₿\ ₿₿ |₿₿ /  \__|₿₿ |₿₿₿\ ₿₿ |₿₿ /  ₿₿ |₿₿ |  ₿₿ |
@@ -11,147 +14,198 @@ echo "
 \________\__|  \__| \______/ \__/     \__|\__|  \__|\__|      
 "
 
-echo "Welcome to LN-STX Bridge Client installation.
-We're glad you've decided to join lnswap.org Swap Provider Network. 
+INTRO="
+Welcome to LN-STX Bridge Client installation.
+We're glad you've decided to join the lnswap.org Swap Provider Network. 
 
-Please confirm you have requirements listed below:
+Please confirm you have the requirements listed below:
 1- Bitcoin full Node (unpruned)
 2- LND Lightning Node 
 3- Always available server/VM/self-hosted node"
-DEFAULT_REQUIREMENTS="n"
-read -erp "y/n: " requirements
-requirements="${requirements:-${DEFAULT_REQUIREMENTS}}"
-if [ "$requirements" != "y" ] ; then
-    echo "Not ready yet, quitting."
-    exit
-fi
 
-echo -e "\nI understand that this is experimental software that may cause loss of funds."
-read -erp "y/n: " reckless
-reckless="${reckless:-${DEFAULT_REQUIREMENTS}}"
-if [ "${reckless}" != "y" ] ; then
-  echo "Not #reckless yet, quitting."
-  exit
-fi
+DISCLAIMER="I understand that this is experimental software that may cause loss of funds."
 
-echo ""
+##### DEFAULT SETTINGS #####
+
 DEFAULT_APP_DATA_DIR="$HOME/.lnstx-client"
-read -erp "Folder where lnstxbridge client will keep its data [$DEFAULT_APP_DATA_DIR]: " APP_DATA_DIR
-APP_DATA_DIR="${APP_DATA_DIR:-${DEFAULT_APP_DATA_DIR}}"
-
 DEFAULT_LND_DATA_DIR="$HOME/.lnd"
-read -erp "Folder where lnd is installed [$DEFAULT_LND_DATA_DIR]: " LND_DATA_DIR
-LND_DATA_DIR="${LND_DATA_DIR:-${DEFAULT_LND_DATA_DIR}}"
-
 DEFAULT_BITCOIN_IP="127.0.0.1"
-read -erp "Bitcoin Node IP [$DEFAULT_BITCOIN_IP]: " BITCOIN_IP
-BITCOIN_IP="${BITCOIN_IP:-${DEFAULT_BITCOIN_IP}}"
-
 DEFAULT_BITCOIN_RPC_PORT="8332"
-read -erp "Bitcoin Node RPC Port [$DEFAULT_BITCOIN_RPC_PORT]: " BITCOIN_RPC_PORT
-BITCOIN_RPC_PORT="${BITCOIN_RPC_PORT:-${DEFAULT_BITCOIN_RPC_PORT}}"
-
 DEFAULT_BITCOIN_RPC_USER="rpcuser"
-read -erp "Bitcoin Node RPC User [$DEFAULT_BITCOIN_RPC_USER]: " BITCOIN_RPC_USER
-BITCOIN_RPC_USER="${BITCOIN_RPC_USER:-${DEFAULT_BITCOIN_RPC_USER}}"
-
 DEFAULT_BITCOIN_RPC_PASS="rpcpass"
-read -erp "Bitcoin Node RPC Password [$DEFAULT_BITCOIN_RPC_PASS]: " BITCOIN_RPC_PASS
-BITCOIN_RPC_PASS="${BITCOIN_RPC_PASS:-${DEFAULT_BITCOIN_RPC_PASS}}"
-
 DEFAULT_BITCOIN_NETWORK="mainnet"
-read -erp "Bitcoin Node Network [$DEFAULT_BITCOIN_NETWORK]: " BITCOIN_NETWORK
-BITCOIN_NETWORK="${BITCOIN_NETWORK:-${DEFAULT_BITCOIN_NETWORK}}"
-
 DEFAULT_LND_IP="127.0.0.1"
-read -erp "LND Node IP [$DEFAULT_LND_IP]: " LND_IP
-LND_IP="${LND_IP:-${DEFAULT_LND_IP}}"
-
 DEFAULT_LND_GRPC_PORT="10009"
-read -erp "LND Node GRPC Port [$DEFAULT_LND_GRPC_PORT]: " LND_GRPC_PORT
-LND_GRPC_PORT="${LND_GRPC_PORT:-${DEFAULT_LND_GRPC_PORT}}"
-
 DEFAULT_APP_PASSWORD="changeme!!!"
-read -erp "LN-STX Client Admin Dashboard Password [$DEFAULT_APP_PASSWORD]: " APP_PASSWORD
-APP_PASSWORD="${APP_PASSWORD:-${DEFAULT_APP_PASSWORD}}"
-
-# use public ipv4 or create hidden service
-echo -e "\nDo you have an IPv4 address that this server is reachable from or is this a self-hosted node that we need to create a tor hidden service?"
 DEFAULT_ACCESS="tor"
-read -erp "ip/tor: " access
-access="${access:-${DEFAULT_ACCESS}}"
-if [ "${access}" == "tor" ] ; then
-  echo "Creating tor hidden service..."
-  {
-    echo "HiddenServiceDir /var/lib/tor/lnswap/"
-    echo "HiddenServicePort 9008 127.0.0.1:9008"
-    echo "HiddenServicePort 80 127.0.0.1:9009"
-  } >> /etc/tor/torrc
-  eval "systemctl restart tor"
-  sleep 5
-  APP_LNSWAP_API_IP=$(cat /var/lib/tor/lnswap/hostname)
-else
-    read -erp "Enter your server IP: " APP_LNSWAP_API_IP
-fi
 
-echo -e "\nInstalling lnstxbridge-client with following environment variables: "
-echo "APP_DATA_DIR: $APP_DATA_DIR"
-echo "LND_DATA_DIR: $LND_DATA_DIR"
-echo "BITCOIN_IP: $BITCOIN_IP"
-echo "BITCOIN_RPC_PORT: $BITCOIN_RPC_PORT"
-echo "BITCOIN_RPC_USER: $BITCOIN_RPC_USER"
-echo "BITCOIN_RPC_PASS: $BITCOIN_RPC_PASS"
-echo "BITCOIN_NETWORK: $BITCOIN_NETWORK"
-echo "LND_IP: $LND_IP"
-echo "LND_GRPC_PORT: $LND_GRPC_PORT"
-echo "APP_PASSWORD: $APP_PASSWORD"
+##### UTILITIES #####
 
-# install docker-compose if missing
-if ! [ -x "$(command -v docker-compose)" ]; then
-    echo "trying to install docker-compose..."
-    VERSION=$(curl --silent https://api.github.com/repos/docker/compose/releases/latest | jq .name -r)
-    DESTINATION=/usr/local/bin/docker-compose
-    sudo curl -L https://github.com/docker/compose/releases/download/"${VERSION}"/docker-compose-"$(uname -s)"-"$(uname -m)" -o $DESTINATION
-    sudo chmod 755 $DESTINATION
-fi
+PANIC="[ PANIC ]"
+ERROR="[ ERROR ]"
+WARN="[ WARN ]"
+INFO="[ INFO ]"
 
-# create lnstxbridge-client data folder
-mkdir -p "$APP_DATA_DIR/data"
+alias log="logger"
+alias log_error='logger "${ERROR}"'
+alias log_warn='logger "${WARN}"'
+alias log_info='logger "${INFO}"'
+alias panic='exit_error "${PANIC}"'
 
-# download docker-compose.yml
-cd "$APP_DATA_DIR" || exit
-curl -O "https://cdn.jsdelivr.net/gh/pseudozach/lnstxbridge-client@main/docker-compose/docker-compose.yml"
+logger() {
+    echo "$@"
+}
 
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    # macos sed is different
-    eval sed -i '' 's#$APP_DATA_DIR#'"$APP_DATA_DIR"'#g' docker-compose.yml
-    eval sed -i '' 's#$LND_DATA_DIR#'"$LND_DATA_DIR"'#g' docker-compose.yml
-    eval sed -i '' 's#$BITCOIN_IP#'"$BITCOIN_IP"'#g' docker-compose.yml
-    eval sed -i '' 's#$BITCOIN_RPC_PORT#'"$BITCOIN_RPC_PORT"'#g' docker-compose.yml
-    eval sed -i '' 's#$BITCOIN_RPC_USER#'"$BITCOIN_RPC_USER"'#g' docker-compose.yml
-    eval sed -i '' 's#$BITCOIN_RPC_PASS#'"$BITCOIN_RPC_PASS"'#g' docker-compose.yml
-    eval sed -i '' 's#$BITCOIN_NETWORK#'"$BITCOIN_NETWORK"'#g' docker-compose.yml
-    eval sed -i '' 's#$LND_IP#'"$LND_IP"'#g' docker-compose.yml
-    eval sed -i '' 's#$LND_GRPC_PORT#'"$LND_GRPC_PORT"'#g' docker-compose.yml
-    eval sed -i '' 's#$APP_PASSWORD#'"$APP_PASSWORD"'#g' docker-compose.yml
-    eval sed -i '' 's#$APP_LNSWAP_API_IP#'"$APP_LNSWAP_API_IP"'#g' docker-compose.yml
-else
-    eval sed -i 's#$APP_DATA_DIR#'"$APP_DATA_DIR"'#g' docker-compose.yml
-    eval sed -i 's#$LND_DATA_DIR#'"$LND_DATA_DIR"'#g' docker-compose.yml
-    eval sed -i 's#$BITCOIN_IP#'"$BITCOIN_IP"'#g' docker-compose.yml
-    eval sed -i 's#$BITCOIN_RPC_PORT#'"$BITCOIN_RPC_PORT"'#g' docker-compose.yml
-    eval sed -i 's#$BITCOIN_RPC_USER#'"$BITCOIN_RPC_USER"'#g' docker-compose.yml
-    eval sed -i 's#$BITCOIN_RPC_PASS#'"$BITCOIN_RPC_PASS"'#g' docker-compose.yml
-    eval sed -i 's#$BITCOIN_NETWORK#'"$BITCOIN_NETWORK"'#g' docker-compose.yml
-    eval sed -i 's#$LND_IP#'"$LND_IP"'#g' docker-compose.yml
-    eval sed -i 's#$LND_GRPC_PORT#'"$LND_GRPC_PORT"'#g' docker-compose.yml
-    eval sed -i 's#$APP_PASSWORD#'"$APP_PASSWORD"'#g' docker-compose.yml
-    eval sed -i 's#$APP_LNSWAP_API_IP#'"$APP_LNSWAP_API_IP"'#g' docker-compose.yml
-fi
+exit_error() {
+    logger "$@"
+    exit 1
+}
 
-# copy boltz.conf template to APP_DATA_DIR/data = /root/.lnstx-client inside container
-cd "$APP_DATA_DIR/data" || exit
-curl -O "https://cdn.jsdelivr.net/gh/pseudozach/lnstxbridge-client@main/docker-compose/lnstx-client/boltz.conf"
+sed_fix() {
+    # usage: sed_fix <placeholder> <value> <file>
+    if [[ "$OSTYPE" == "darwin"* ]]; then 
+        sed -i '' "s|\$${1}|${2}|g" "${3}"
+    else
+        sed -i "s|\$${1}|${2}|g" "${3}"
+    fi
+}
 
-# start containers
-docker-compose up -d
+##### MAIN EXECUTION #####
+
+main() {
+    echo "$LOGO"
+    echo "$INTRO"
+    check_prereq
+    set_config
+    set_network
+    show_config
+    check_docker
+    install_bridge
+}
+
+check_prereq() {
+    read -erp "Answer (y/n): " requirements
+    if [ "$requirements" != "y" ]; then
+        panic "Default requirements not confirmed, quitting."
+    fi
+    echo
+    echo "$DISCLAIMER"
+    read -erp "Answer (y/n): " reckless
+    if [ "${reckless}" != "y" ]; then
+        panic "Disclaimer not confirmed, quitting."
+    fi
+}
+
+set_config() {
+    echo
+    echo "Setting configuration settings for LN-STX Bridge..."
+    read -erp "  Folder where lnstxbridge client will keep its data [$DEFAULT_APP_DATA_DIR]: " APP_DATA_DIR
+    APP_DATA_DIR="${APP_DATA_DIR:-${DEFAULT_APP_DATA_DIR}}"
+    read -erp "  Folder where lnd is installed [$DEFAULT_LND_DATA_DIR]: " LND_DATA_DIR
+    LND_DATA_DIR="${LND_DATA_DIR:-${DEFAULT_LND_DATA_DIR}}"
+    read -erp "  Bitcoin Node IP [$DEFAULT_BITCOIN_IP]: " BITCOIN_IP
+    BITCOIN_IP="${BITCOIN_IP:-${DEFAULT_BITCOIN_IP}}"
+    read -erp "  Bitcoin Node RPC Port [$DEFAULT_BITCOIN_RPC_PORT]: " BITCOIN_RPC_PORT
+    BITCOIN_RPC_PORT="${BITCOIN_RPC_PORT:-${DEFAULT_BITCOIN_RPC_PORT}}"
+    read -erp "  Bitcoin Node RPC User [$DEFAULT_BITCOIN_RPC_USER]: " BITCOIN_RPC_USER
+    BITCOIN_RPC_USER="${BITCOIN_RPC_USER:-${DEFAULT_BITCOIN_RPC_USER}}"
+    read -erp "  Bitcoin Node RPC Password [$DEFAULT_BITCOIN_RPC_PASS]: " BITCOIN_RPC_PASS
+    BITCOIN_RPC_PASS="${BITCOIN_RPC_PASS:-${DEFAULT_BITCOIN_RPC_PASS}}"
+    read -erp "  Bitcoin Node Network [$DEFAULT_BITCOIN_NETWORK]: " BITCOIN_NETWORK
+    BITCOIN_NETWORK="${BITCOIN_NETWORK:-${DEFAULT_BITCOIN_NETWORK}}"
+    read -erp "  LND Node IP [$DEFAULT_LND_IP]: " LND_IP
+    LND_IP="${LND_IP:-${DEFAULT_LND_IP}}"
+    read -erp "  LND Node GRPC Port [$DEFAULT_LND_GRPC_PORT]: " LND_GRPC_PORT
+    LND_GRPC_PORT="${LND_GRPC_PORT:-${DEFAULT_LND_GRPC_PORT}}"
+    read -erp "  LN-STX Client Admin Dashboard Password [$DEFAULT_APP_PASSWORD]: " APP_PASSWORD
+    APP_PASSWORD="${APP_PASSWORD:-${DEFAULT_APP_PASSWORD}}"
+}
+
+set_network() {
+    # use public ipv4 or create hidden service
+    echo
+    echo "Do you have an IPv4 address that this server is reachable from or is this a self-hosted node that we need to create a tor hidden service?"
+    read -erp "Answer (ip/tor): " ACCESS
+    ACCESS="${ACCESS:-${DEFAULT_ACCESS}}"
+    if [ "${ACCESS}" == "tor" ] || [ "${ACCESS}" == "TOR" ] ; then
+        log_info "Creating tor hidden service..."
+        {
+            echo "HiddenServiceDir /var/lib/tor/lnswap/"
+            echo "HiddenServicePort 9008 127.0.0.1:9008"
+            echo "HiddenServicePort 80 127.0.0.1:9009"
+        } >> /etc/tor/torrc
+        log_info "Restarting tor service..."
+        eval "systemctl restart tor"
+        sleep 5
+        APP_LNSWAP_API_IP=$(cat /var/lib/tor/lnswap/hostname)
+    elif [ "${ACCESS}" == "ip" ] || [ "${ACCESS}" == "IP" ] ; then
+        read -erp "  Enter your server IP: " APP_LNSWAP_API_IP
+    else
+        panic "Invalid network selection, quitting."
+    fi
+}
+
+show_config() {
+    echo
+    echo "Installing lnstxbridge-client with following environment variables: "
+    echo "  APP_DATA_DIR: $APP_DATA_DIR"
+    echo "  LND_DATA_DIR: $LND_DATA_DIR"
+    echo "  BITCOIN_IP: $BITCOIN_IP"
+    echo "  BITCOIN_RPC_PORT: $BITCOIN_RPC_PORT"
+    echo "  BITCOIN_RPC_USER: $BITCOIN_RPC_USER"
+    echo "  BITCOIN_RPC_PASS: $BITCOIN_RPC_PASS"
+    echo "  BITCOIN_NETWORK: $BITCOIN_NETWORK"
+    echo "  LND_IP: $LND_IP"
+    echo "  LND_GRPC_PORT: $LND_GRPC_PORT"
+    echo "  APP_PASSWORD: $APP_PASSWORD"
+    echo "  ACCESS: $ACCESS"
+    echo "  APP_LNSWAP_API_IP: $APP_LNSWAP_API_IP"
+
+    # TODO: should $APP_HIDDEN_SERVICE and $APP_PORT be here?
+}
+
+check_docker() {
+    # install docker-compose if missing
+    if ! [ -x "$(command -v docker-compose)" ]; then
+        echo "trying to install docker-compose..."
+        VERSION=$(curl -sS https://api.github.com/repos/docker/compose/releases/latest | jq .name -r)
+        DESTINATION=/usr/local/bin/docker-compose
+        sudo curl -L https://github.com/docker/compose/releases/download/"${VERSION}"/docker-compose-"$(uname -s)"-"$(uname -m)" -o $DESTINATION
+        sudo chmod 755 $DESTINATION
+    fi
+}
+
+install_bridge() {
+    # create lnstxbridge-client data folder
+    mkdir -p "$APP_DATA_DIR/data"
+    cd "$APP_DATA_DIR" || exit
+    # download docker-compose.yml
+    curl -sSO "https://cdn.jsdelivr.net/gh/pseudozach/lnstxbridge-client@main/docker-compose/docker-compose.yml"
+    # replace variables in docker-compose.yml
+    sed_fix "APP_DATA_DIR" "$APP_DATA_DIR" "$APP_DATA_DIR/docker-compose.yml"
+    sed_fix "LND_DATA_DIR" "$LND_DATA_DIR" "$APP_DATA_DIR/docker-compose.yml"
+    sed_fix "BITCOIN_IP" "$BITCOIN_IP" "$APP_DATA_DIR/docker-compose.yml"
+    sed_fix "BITCOIN_RPC_PORT" "$BITCOIN_RPC_PORT" "$APP_DATA_DIR/docker-compose.yml"
+    sed_fix "BITCOIN_RPC_USER" "$BITCOIN_RPC_USER" "$APP_DATA_DIR/docker-compose.yml"
+    sed_fix "BITCOIN_RPC_PASS" "$BITCOIN_RPC_PASS" "$APP_DATA_DIR/docker-compose.yml"
+    sed_fix "BITCOIN_NETWORK" "$BITCOIN_NETWORK" "$APP_DATA_DIR/docker-compose.yml"
+    sed_fix "LND_IP" "$LND_IP" "$APP_DATA_DIR/docker-compose.yml"
+    sed_fix "LND_GRPC_PORT" "$LND_GRPC_PORT" "$APP_DATA_DIR/docker-compose.yml"
+    sed_fix "APP_PASSWORD" "$APP_PASSWORD" "$APP_DATA_DIR/docker-compose.yml"
+    sed_fix "APP_LNSWAP_API_IP" "$APP_LNSWAP_API_IP" "$APP_DATA_DIR/docker-compose.yml"
+    
+    # TODO: should $APP_HIDDEN_SERVICE and $APP_PORT be set here?
+    
+    # copy boltz.conf template to APP_DATA_DIR/data = /root/.lnstx-client inside container
+    cd "$APP_DATA_DIR/data" || exit
+    curl -sSO "https://cdn.jsdelivr.net/gh/pseudozach/lnstxbridge-client@main/docker-compose/lnstx-client/boltz.conf"
+    
+    # start containers
+    docker-compose up -d
+}
+
+main
+
+echo
+echo "END OF SCRIPT"
+exit 0


### PR DESCRIPTION
This PR takes the changes from #11 and expands on it thanks to inspiration from the [ABC STX Miner Script](https://github.com/AbsorbingChaos/stx-miner-script/blob/master/config-miner-krypton.sh) and the [Stacks Blockchain Docker manage.sh script](https://github.com/stacks-network/stacks-blockchain-docker/blob/master/manage.sh).

Some of the changes include:
- sets options at the top to make sure script runs correctly [reference](https://gist.github.com/mohanpedala/1e2ff5661761d3abd0385e8223e16425)
- moves intro / logo / disclaimer to variables at the top
- moves default settings to the top
- adds logging utilities (thanks @wileyj!)
- refactors the `sed` differences between OS into a custom function
- updates text, formatting, and layout while running

Every action taken by the script is divided into separate functions, with a `main()` function that is called at the end to run through each.

Some open items:
- needs testing on a mac, I'm on Linux and currently booting a fresh Ubuntu 22.04 VM to test
- do we want to add colors to each status? [reference](https://github.com/stacks-network/stacks-blockchain-docker/blob/a62825d4ad8a76c1097526e0d07c4b5fca6f617a/manage.sh#L22-L30)
- should there be a more in-depth check for the Bitcoin/LND node? (e.g. try to verify address + ports)
- does the `docker-compose` install work without having any other parts of Docker installed? (will try this once the VM is up)
- could [this docker-compose.yml](https://github.com/LNSwap/lnstxbridge-client/blob/main/docker-compose/docker-compose.yml) be used instead of the [downloaded version](https://cdn.jsdelivr.net/gh/pseudozach/lnstxbridge-client@main/docker-compose/docker-compose.yml)?

I'm definitely open to feedback here but wanted to make a first pass to show what I was thinking!